### PR TITLE
Run imputationbot without jar in same directory

### DIFF
--- a/files/imputationbot
+++ b/files/imputationbot
@@ -1,3 +1,6 @@
 #!/bin/bash
+
+# Get directory with imputationbot.jar
+BASEDIR=$(dirname "$0")
 export JAVA_PROGRAM_ARGS=`echo "$@"`
-java -jar imputationbot.jar $JAVA_PROGRAM_ARGS
+java -jar $BASEDIR/imputationbot.jar $JAVA_PROGRAM_ARGS


### PR DESCRIPTION
The imputationbot script currently expect imputationbot.jar to be in the current directory. Change to allow the script and jar to be in a different directory together.