### PR TITLE
Resolve recursive waitForJob method

### DIFF
--- a/src/main/java/genepi/imputationbot/client/CloudgeneClient.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneClient.java
@@ -136,9 +136,9 @@ public class CloudgeneClient {
 	public void waitForProject(Project project, int pollingTime) throws CloudgeneException, InterruptedException {
 
 		for (ProjectJob job : project.getJobs()) {
-			waitForJob(job.getJob(), pollingTime);
+			//noinspection StatementWithEmptyBody
+			while(!waitForJob(job.getJob(), pollingTime)){}
 		}
-
 	}
 
 	public void waitForJob(CloudgeneJob job) throws CloudgeneException, InterruptedException {
@@ -146,10 +146,14 @@ public class CloudgeneClient {
 	}
 
 	public void waitForJob(String id) throws CloudgeneException, InterruptedException {
-		waitForJob(id, 10000);
+		//noinspection StatementWithEmptyBody
+		while(!waitForJob(id, 10000)){}
 	}
 
-	public void waitForJob(String id, int pollingTime) throws CloudgeneException, InterruptedException {
+	/**
+	 * return true if job is complete, false if time ran out
+	 * */
+	public boolean waitForJob(String id, int pollingTime) throws CloudgeneException, InterruptedException {
 
 		CloudgeneInstance instance = getInstanceByJobId(id);
 
@@ -159,9 +163,14 @@ public class CloudgeneClient {
 
 		if (job.isRunning()) {
 			Thread.sleep(pollingTime);
-			waitForJob(id, pollingTime);
 		} else {
 			Thread.sleep(5000);
+		}
+
+		if (job.isRunning()) {
+			return false;
+		} else {
+			return true;
 		}
 
 	}

--- a/src/main/java/genepi/imputationbot/commands/DownloadResults.java
+++ b/src/main/java/genepi/imputationbot/commands/DownloadResults.java
@@ -52,7 +52,6 @@ public class DownloadResults extends BaseCommand {
 			for (int i = 0; i < project.getJobs().size(); i++) {
 				jobIds[i] = project.getJobs().get(i).getJob();
 			}
-
 		}
 
 		for (int i = 0; i < jobIds.length; i++) {
@@ -62,7 +61,9 @@ public class DownloadResults extends BaseCommand {
 
 			if (job.isRunning()) {
 				println("Job " + job.getId() + " is running. Download starts automatically when job is finished...");
-				client.waitForJob(job.getId(), 30 * 1000);
+				// noinspection StatementWithEmptyBody
+				while(!client.waitForJob(job.getId(), 30 * 1000)){}
+
 				job = client.getJobDetails(job.getId());
 
 				println("Job completed. State: " + job.getJobStateAsText());


### PR DESCRIPTION
This PR changes the method CloudgeneClient::waitForJob(String id, int pollingTime) so that it is no longer recursive. In long-running jobs, the recursion causes a stack overflow (see issue #16) and I think that this is the source.

fix: #16 