### PR TITLE
Remove link to the development server for the TOPMed Imputation Server

### DIFF
--- a/docs/public-instances.md
+++ b/docs/public-instances.md
@@ -18,8 +18,8 @@ Url: [http://imputationsever.sph.umich](http://imputationsever.sph.umich)
 
 ## TOPMed Imputation Server
 
-Url: [https://topmed.dev.imputationserver.org](https://topmed.dev.imputationserver.org)
+Url: [https://imputation.biodatacatalyst.nhlbi.nih.gov](https://imputation.biodatacatalyst.nhlbi.nih.gov)
 
 ### Reference Panels
 
-- `topmed-r2` TOPMed (Version R2 on GRC38)
+- `topmed-r3` TOPMed (Version R3 on GRC38)


### PR DESCRIPTION
Currently, the documentation page "Public instances" contains a link to the TOPMed Imputation Server's development URL. This URL is only intended for the server's maintainers and should not be publicly exposed.

This change updates the link so it points to the public production server, and updates the reference panel information (TOPMed R2 -> TOPMed R3).