### PR TITLE
Fix compatibility with TOPMed Imputation Server

### DIFF
--- a/src/main/java/genepi/imputationbot/client/CloudgeneApplication.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneApplication.java
@@ -1,0 +1,24 @@
+package genepi.imputationbot.client;
+
+import org.json.JSONObject;
+
+public class CloudgeneApplication {
+
+    private final JSONObject app;
+
+    public CloudgeneApplication(JSONObject app) {
+        this.app = app;
+    }
+
+    public String getId() {
+        return app.getString("id");
+    }
+
+    public String getName() {
+        return app.getString("name");
+    }
+
+    public String getVersion() {
+        return app.getString("version");
+    }
+}

--- a/src/main/java/genepi/imputationbot/client/CloudgeneClient.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneClient.java
@@ -45,9 +45,9 @@ public class CloudgeneClient {
 		this.instances = instances;
 	}
 
-	public CloudgeneUser getAuthUser(CloudgeneInstance instance) throws CloudgeneException {
+	public CloudgeneUser getAuthUser(CloudgeneInstance instance, String username) throws CloudgeneException {
 
-		String content = get(instance, "/api/v2/users/me/profile");
+		String content = get(instance, "/api/v2/users/" + username + "/profile");
 		JSONObject object = new JSONObject(content);
 		return new CloudgeneUser(object);
 
@@ -67,24 +67,22 @@ public class CloudgeneClient {
 
 	}
 
-	public JSONObject getServerDetails(CloudgeneInstance instance) throws CloudgeneException {
+	public CloudgeneServerDetails getServerDetails(CloudgeneInstance instance) throws CloudgeneException {
 
 		String content = get(instance, "/api/v2/server");
 		JSONObject object = new JSONObject(content);
-		return object;
-
+		return new CloudgeneServerDetails(object);
 	}
 
 	public JSONObject getAppByIds(CloudgeneInstance instance, String[] ids, Version minVersion)
 			throws CloudgeneException, CloudgeneAppException {
 
-		JSONObject server = getServerDetails(instance);
-		JSONArray apps = server.getJSONArray("apps");
+		CloudgeneServerDetails server = getServerDetails(instance);
+		List<CloudgeneApplication> apps = server.getApps();
 
 		// search for application by id
-		for (int i = 0; i < apps.length(); i++) {
-			JSONObject app = apps.getJSONObject(i);
-			String id = app.get("id").toString();
+		for (CloudgeneApplication app : apps) {
+			String id = app.getId();
 			CloudgeneAppId appId = new CloudgeneAppId(id);
 
 			for (String _id : ids) {

--- a/src/main/java/genepi/imputationbot/client/CloudgeneInstance.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneInstance.java
@@ -39,8 +39,8 @@ public class CloudgeneInstance {
 	public String getName() throws CloudgeneException {
 		if (name == null) {
 			CloudgeneClient client = new CloudgeneClient(new Vector<CloudgeneInstance>());
-			JSONObject server = client.getServerDetails(this);
-			name = server.getString("name");
+			CloudgeneServerDetails server = client.getServerDetails(this);
+			name = server.getName();
 		}
 		return name;
 	}

--- a/src/main/java/genepi/imputationbot/client/CloudgeneServerDetails.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneServerDetails.java
@@ -1,0 +1,38 @@
+package genepi.imputationbot.client;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CloudgeneServerDetails {
+
+    private final JSONObject details;
+
+    public CloudgeneServerDetails(JSONObject details) {
+        this.details = details;
+    }
+
+    public String getName() {
+        return details.getString("name");
+    }
+
+    public CloudgeneUser getUser() {
+        JSONObject user = details.getJSONObject("user");
+        return new CloudgeneUser(user);
+    }
+
+    public List<CloudgeneApplication> getApps() {
+        List<CloudgeneApplication> processed = new ArrayList<>();
+        JSONArray raw = details.getJSONArray("apps");
+
+        for (int i = 0; i < raw.length(); ++i) {
+            JSONObject r = raw.getJSONObject(i);
+            CloudgeneApplication p = new CloudgeneApplication(r);
+            processed.add(p);
+        }
+
+        return processed;
+    }
+}

--- a/src/main/java/genepi/imputationbot/client/CloudgeneUser.java
+++ b/src/main/java/genepi/imputationbot/client/CloudgeneUser.java
@@ -2,16 +2,34 @@ package genepi.imputationbot.client;
 
 import org.json.JSONObject;
 
+import java.util.regex.Pattern;
+
 public class CloudgeneUser {
 
-	private JSONObject user;
+	private final JSONObject user;
 
 	public CloudgeneUser(JSONObject user) {
 		this.user = user;
 	}
 
 	public String getFullName() {
-		return user.getString("fullName").isEmpty() ? "Mr. Shy" : user.getString("fullName");
+        // Parsed from /users/{username}/profile
+        if (user.has("fullName")) {
+            String fullName = user.getString("fullName");
+            if (!fullName.isEmpty()) {
+                return fullName;
+            }
+        }
+
+        // Parsed from /server
+        if (user.has("name")) {
+            String name = user.getString("name");
+            if (!name.isEmpty()) {
+                return name;
+            }
+        }
+
+        return "Mr. Shy";
 	}
 
 	public String getMail() {

--- a/src/main/java/genepi/imputationbot/commands/AddInstance.java
+++ b/src/main/java/genepi/imputationbot/commands/AddInstance.java
@@ -1,13 +1,8 @@
 package genepi.imputationbot.commands;
 
+import genepi.imputationbot.client.*;
 import org.json.JSONObject;
 
-import genepi.imputationbot.client.CloudgeneApiToken;
-import genepi.imputationbot.client.CloudgeneClient;
-import genepi.imputationbot.client.CloudgeneException;
-import genepi.imputationbot.client.CloudgeneInstance;
-import genepi.imputationbot.client.CloudgeneInstanceList;
-import genepi.imputationbot.client.CloudgeneUser;
 import genepi.imputationbot.util.Emoji;
 
 public class AddInstance extends BaseCommand {
@@ -77,7 +72,9 @@ public class AddInstance extends BaseCommand {
 		}
 
 		// test api token by getting user profile
-		CloudgeneUser user = client.getAuthUser(instance);
+        CloudgeneServerDetails serverDetails = client.getServerDetails(instance);
+        CloudgeneUser user = serverDetails.getUser();
+
 		println();
 		println("Hi " + user.getFullName() + " " + Emoji.WAVING_HAND);
 		println();

--- a/src/main/java/genepi/imputationbot/commands/ListInstances.java
+++ b/src/main/java/genepi/imputationbot/commands/ListInstances.java
@@ -3,13 +3,9 @@ package genepi.imputationbot.commands;
 import java.util.List;
 import java.util.Vector;
 
+import genepi.imputationbot.client.*;
 import org.json.JSONObject;
 
-import genepi.imputationbot.client.CloudgeneApiToken;
-import genepi.imputationbot.client.CloudgeneClient;
-import genepi.imputationbot.client.CloudgeneException;
-import genepi.imputationbot.client.CloudgeneInstance;
-import genepi.imputationbot.client.CloudgeneUser;
 import genepi.imputationbot.util.AnsiColors;
 import genepi.imputationbot.util.FlipTable;
 
@@ -61,10 +57,11 @@ public class ListInstances extends BaseCommand {
 			try {
 			CloudgeneApiToken token = client.verifyToken(instance, instance.getToken());
 			if (token.isValid() && !token.isExpired()) {
-				JSONObject server = client.getServerDetails(instance);
+                CloudgeneServerDetails serverDetails = client.getServerDetails(instance);
+                CloudgeneUser user = serverDetails.getUser();
 				JSONObject app = client.getDefaultApp(instance);
-				CloudgeneUser user = client.getAuthUser(instance);
-				data[i][1] = server.getString("name");
+
+				data[i][1] = serverDetails.getName();
 				data[i][2] = instance.getHostname();
 				data[i][3] = user.getUsername();
 				data[i][4] = app.getString("version");

--- a/src/main/java/genepi/imputationbot/commands/UpdateInstance.java
+++ b/src/main/java/genepi/imputationbot/commands/UpdateInstance.java
@@ -1,13 +1,8 @@
 package genepi.imputationbot.commands;
 
+import genepi.imputationbot.client.*;
 import org.json.JSONObject;
 
-import genepi.imputationbot.client.CloudgeneApiToken;
-import genepi.imputationbot.client.CloudgeneClient;
-import genepi.imputationbot.client.CloudgeneException;
-import genepi.imputationbot.client.CloudgeneInstance;
-import genepi.imputationbot.client.CloudgeneInstanceList;
-import genepi.imputationbot.client.CloudgeneUser;
 import genepi.imputationbot.util.Console;
 import genepi.imputationbot.util.Emoji;
 
@@ -109,7 +104,9 @@ public class UpdateInstance extends BaseCommand {
 		}
 
 		// test api token by getting user profile
-		CloudgeneUser user = client.getAuthUser(instance);
+        CloudgeneServerDetails serverDetails = client.getServerDetails(instance);
+        CloudgeneUser user = serverDetails.getUser();
+
 		println();
 		println("Hi " + user.getFullName() + " " + Emoji.WAVING_HAND);
 		println();


### PR DESCRIPTION
Avoid dummy value `username="me"` when calling `/api/v2/users/{username}/profile`

The TOPMed Imputation Server is running with custom changes that require `username` to be the correct user (used for admin user detail pages).

This change recovers imputationbot compatibility with the TOPMed Imputation Server by parsing basic user data from the `/api/v2/server` endpoint instead.